### PR TITLE
BREAKING: Fix user and organization API security issue

### DIFF
--- a/context/serializers.py
+++ b/context/serializers.py
@@ -1,15 +1,15 @@
-from rest_framework import serializers
+from neatplus.serializers import UserModelSerializer
 
 from .models import Context, Module
 
 
-class ContextSerializer(serializers.ModelSerializer):
+class ContextSerializer(UserModelSerializer):
     class Meta:
         model = Context
         fields = "__all__"
 
 
-class ModuleSerializer(serializers.ModelSerializer):
+class ModuleSerializer(UserModelSerializer):
     class Meta:
         model = Module
         fields = "__all__"

--- a/docker/entrypoint.dev.sh
+++ b/docker/entrypoint.dev.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-poetry install
+poetry install --no-root
 if [ "$CELERY_WORKER" = "true" ]
 then
     if [ -z "$CELERY_QUEUES" ]

--- a/docker/entrypoint.test.sh
+++ b/docker/entrypoint.test.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
-poetry install
+poetry install --no-root
 poetry run ./manage.py collectstatic --no-input
 poetry run ./manage.py test -v 3

--- a/kubernetes/ingress/ingress.yml
+++ b/kubernetes/ingress/ingress.yml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     kubernetes.io/ingress.class: nginx
     certmanager.k8s.io/cluster-issuer: letsencrypt-issuer
+    nginx.ingress.kubernetes.io/proxy-body-size: 8m
 spec:
   tls:
   - hosts:

--- a/locale/es/LC_MESSAGES/django.po
+++ b/locale/es/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-18 08:53+0000\n"
+"POT-Creation-Date: 2022-03-21 04:59+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -248,19 +248,35 @@ msgstr ""
 msgid "user"
 msgstr ""
 
-#: organization/views.py:46 organization/views.py:68
+#: organization/views.py:49 organization/views.py:71
 msgid "Successfully created project"
 msgstr ""
 
-#: organization/views.py:77 organization/views.py:95
+#: organization/views.py:80 organization/views.py:98
 msgid "Successfully requested member access"
 msgstr ""
 
-#: organization/views.py:122 organization/views.py:139
+#: organization/views.py:130 organization/views.py:161
+msgid "Successfully added all valid users"
+msgstr ""
+
+#: organization/views.py:158
+msgid "Failed to add users to organization"
+msgstr ""
+
+#: organization/views.py:169 organization/views.py:200
+msgid "Successfully removed all valid users"
+msgstr ""
+
+#: organization/views.py:197
+msgid "Failed to remove users from organization"
+msgstr ""
+
+#: organization/views.py:225 organization/views.py:242
 msgid "Member request successfully accepted"
 msgstr ""
 
-#: organization/views.py:146 organization/views.py:163
+#: organization/views.py:249 organization/views.py:266
 msgid "Member request successfully rejected"
 msgstr ""
 
@@ -321,11 +337,11 @@ msgstr ""
 msgid "permission"
 msgstr ""
 
-#: project/serializers.py:56
+#: project/serializers.py:57
 msgid "Cannot create project for not accepted organization"
 msgstr ""
 
-#: project/serializers.py:65
+#: project/serializers.py:66
 msgid ""
 "No organization project cannot have public_within_organization visibility"
 msgstr ""
@@ -882,142 +898,142 @@ msgid_plural "Your password must not contain last {count} password"
 msgstr[0] ""
 msgstr[1] ""
 
-#: user/serializers.py:35
+#: user/serializers.py:41
 msgid "Password field missing"
 msgstr ""
 
-#: user/serializers.py:39 user/serializers.py:54 user/serializers.py:75
+#: user/serializers.py:45 user/serializers.py:60 user/serializers.py:85
 msgid "Invalid password for user"
 msgstr ""
 
-#: user/serializers.py:72
-msgid "Email is already used"
-msgstr ""
-
-#: user/serializers.py:118 user/views.py:317
-msgid "Password and re_password doesn't match"
-msgstr ""
-
-#: user/views.py:67 user/views.py:96
-msgid "Password successfully updated"
-msgstr ""
-
-#: user/views.py:91
+#: user/serializers.py:64
 msgid "New password and re new password doesn't match"
 msgstr ""
 
-#: user/views.py:104 user/views.py:143
+#: user/serializers.py:82
+msgid "Email is already used"
+msgstr ""
+
+#: user/serializers.py:128 user/views.py:324
+msgid "Password and re_password doesn't match"
+msgstr ""
+
+#: user/views.py:75 user/views.py:103
+msgid "Password successfully updated"
+msgstr ""
+
+#: user/views.py:111 user/views.py:150
 msgid "User successfully registered and email send to user's email address"
 msgstr ""
 
-#: user/views.py:127
+#: user/views.py:134
 msgid "User with username/email already exists"
 msgstr ""
 
-#: user/views.py:154 user/views.py:202
+#: user/views.py:161 user/views.py:209
 msgid "Password reset email successfully send"
 msgstr ""
 
-#: user/views.py:179
+#: user/views.py:186
 msgid "No active user present for username/email your account may be blocked"
 msgstr ""
 
-#: user/views.py:229 user/views.py:309
+#: user/views.py:236 user/views.py:316
 msgid "No active user present for username/email"
 msgstr ""
 
-#: user/views.py:250 user/views.py:337
+#: user/views.py:257 user/views.py:344
 msgid "User is inactive"
 msgstr ""
 
-#: user/views.py:257 user/views.py:344 user/views.py:492 user/views.py:618
+#: user/views.py:264 user/views.py:351 user/views.py:501 user/views.py:627
 msgid "User is now inactive for trying too many times"
 msgstr ""
 
-#: user/views.py:262
+#: user/views.py:269
 msgid "Password reset pin is incorrect"
 msgstr ""
 
-#: user/views.py:267 user/views.py:354
+#: user/views.py:274 user/views.py:361
 msgid "Password reset pin has expired"
 msgstr ""
 
-#: user/views.py:271 user/views.py:358
+#: user/views.py:278 user/views.py:365
 msgid "No matching active user pin found"
 msgstr ""
 
-#: user/views.py:285 user/views.py:372
+#: user/views.py:292 user/views.py:381
 msgid "Password successfully changed"
 msgstr ""
 
-#: user/views.py:349
+#: user/views.py:356
 msgid "Password reset identifier is incorrect"
 msgstr ""
 
-#: user/views.py:379 user/views.py:436
+#: user/views.py:388 user/views.py:445
 msgid "Email confirmation mail successfully sent"
 msgstr ""
 
-#: user/views.py:402
+#: user/views.py:411
 msgid "No user present with given email address/username"
 msgstr ""
 
-#: user/views.py:409 user/views.py:546
+#: user/views.py:418 user/views.py:555
 msgid "User is inactive for trying too many times"
 msgstr ""
 
-#: user/views.py:414
+#: user/views.py:423
 msgid "Email address has already been confirmed"
 msgstr ""
 
-#: user/views.py:443 user/views.py:515
+#: user/views.py:452 user/views.py:524
 msgid "Email successfully confirmed"
 msgstr ""
 
-#: user/views.py:467
+#: user/views.py:476
 msgid "No inactive user present for username"
 msgstr ""
 
-#: user/views.py:485
+#: user/views.py:494
 msgid "Email is already confirmed for user"
 msgstr ""
 
-#: user/views.py:497
+#: user/views.py:506
 msgid "Email confirmation pin is incorrect"
 msgstr ""
 
-#: user/views.py:502
+#: user/views.py:511
 msgid "Email confirmation pin has expired"
 msgstr ""
 
-#: user/views.py:506
+#: user/views.py:515
 msgid "No matching active username/email found"
 msgstr ""
 
-#: user/views.py:522 user/views.py:570
+#: user/views.py:531 user/views.py:579
 msgid "Email change mail successfully sent"
 msgstr ""
 
-#: user/views.py:576 user/views.py:646
+#: user/views.py:585 user/views.py:655
 msgid "Email successfully changed"
 msgstr ""
 
-#: user/views.py:611
+#: user/views.py:620
 msgid "Email is already changed for user"
 msgstr ""
 
-#: user/views.py:623
+#: user/views.py:632
 msgid "Email change pin is incorrect"
 msgstr ""
 
-#: user/views.py:628
+#: user/views.py:637
 msgid "Email change pin has expired"
 msgstr ""
 
-#: user/views.py:632
+#: user/views.py:641
 msgid "No matching active change change request found"
 msgstr ""
 
-#: user/views.py:641
+#: user/views.py:650
 msgid "email already used for account creation"
 msgstr ""

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-18 08:53+0000\n"
+"POT-Creation-Date: 2022-03-21 04:59+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -248,19 +248,35 @@ msgstr ""
 msgid "user"
 msgstr ""
 
-#: organization/views.py:46 organization/views.py:68
+#: organization/views.py:49 organization/views.py:71
 msgid "Successfully created project"
 msgstr ""
 
-#: organization/views.py:77 organization/views.py:95
+#: organization/views.py:80 organization/views.py:98
 msgid "Successfully requested member access"
 msgstr ""
 
-#: organization/views.py:122 organization/views.py:139
+#: organization/views.py:130 organization/views.py:161
+msgid "Successfully added all valid users"
+msgstr ""
+
+#: organization/views.py:158
+msgid "Failed to add users to organization"
+msgstr ""
+
+#: organization/views.py:169 organization/views.py:200
+msgid "Successfully removed all valid users"
+msgstr ""
+
+#: organization/views.py:197
+msgid "Failed to remove users from organization"
+msgstr ""
+
+#: organization/views.py:225 organization/views.py:242
 msgid "Member request successfully accepted"
 msgstr ""
 
-#: organization/views.py:146 organization/views.py:163
+#: organization/views.py:249 organization/views.py:266
 msgid "Member request successfully rejected"
 msgstr ""
 
@@ -321,11 +337,11 @@ msgstr ""
 msgid "permission"
 msgstr ""
 
-#: project/serializers.py:56
+#: project/serializers.py:57
 msgid "Cannot create project for not accepted organization"
 msgstr ""
 
-#: project/serializers.py:65
+#: project/serializers.py:66
 msgid ""
 "No organization project cannot have public_within_organization visibility"
 msgstr ""
@@ -882,142 +898,142 @@ msgid_plural "Your password must not contain last {count} password"
 msgstr[0] ""
 msgstr[1] ""
 
-#: user/serializers.py:35
+#: user/serializers.py:41
 msgid "Password field missing"
 msgstr ""
 
-#: user/serializers.py:39 user/serializers.py:54 user/serializers.py:75
+#: user/serializers.py:45 user/serializers.py:60 user/serializers.py:85
 msgid "Invalid password for user"
 msgstr ""
 
-#: user/serializers.py:72
-msgid "Email is already used"
-msgstr ""
-
-#: user/serializers.py:118 user/views.py:317
-msgid "Password and re_password doesn't match"
-msgstr ""
-
-#: user/views.py:67 user/views.py:96
-msgid "Password successfully updated"
-msgstr ""
-
-#: user/views.py:91
+#: user/serializers.py:64
 msgid "New password and re new password doesn't match"
 msgstr ""
 
-#: user/views.py:104 user/views.py:143
+#: user/serializers.py:82
+msgid "Email is already used"
+msgstr ""
+
+#: user/serializers.py:128 user/views.py:324
+msgid "Password and re_password doesn't match"
+msgstr ""
+
+#: user/views.py:75 user/views.py:103
+msgid "Password successfully updated"
+msgstr ""
+
+#: user/views.py:111 user/views.py:150
 msgid "User successfully registered and email send to user's email address"
 msgstr ""
 
-#: user/views.py:127
+#: user/views.py:134
 msgid "User with username/email already exists"
 msgstr ""
 
-#: user/views.py:154 user/views.py:202
+#: user/views.py:161 user/views.py:209
 msgid "Password reset email successfully send"
 msgstr ""
 
-#: user/views.py:179
+#: user/views.py:186
 msgid "No active user present for username/email your account may be blocked"
 msgstr ""
 
-#: user/views.py:229 user/views.py:309
+#: user/views.py:236 user/views.py:316
 msgid "No active user present for username/email"
 msgstr ""
 
-#: user/views.py:250 user/views.py:337
+#: user/views.py:257 user/views.py:344
 msgid "User is inactive"
 msgstr ""
 
-#: user/views.py:257 user/views.py:344 user/views.py:492 user/views.py:618
+#: user/views.py:264 user/views.py:351 user/views.py:501 user/views.py:627
 msgid "User is now inactive for trying too many times"
 msgstr ""
 
-#: user/views.py:262
+#: user/views.py:269
 msgid "Password reset pin is incorrect"
 msgstr ""
 
-#: user/views.py:267 user/views.py:354
+#: user/views.py:274 user/views.py:361
 msgid "Password reset pin has expired"
 msgstr ""
 
-#: user/views.py:271 user/views.py:358
+#: user/views.py:278 user/views.py:365
 msgid "No matching active user pin found"
 msgstr ""
 
-#: user/views.py:285 user/views.py:372
+#: user/views.py:292 user/views.py:381
 msgid "Password successfully changed"
 msgstr ""
 
-#: user/views.py:349
+#: user/views.py:356
 msgid "Password reset identifier is incorrect"
 msgstr ""
 
-#: user/views.py:379 user/views.py:436
+#: user/views.py:388 user/views.py:445
 msgid "Email confirmation mail successfully sent"
 msgstr ""
 
-#: user/views.py:402
+#: user/views.py:411
 msgid "No user present with given email address/username"
 msgstr ""
 
-#: user/views.py:409 user/views.py:546
+#: user/views.py:418 user/views.py:555
 msgid "User is inactive for trying too many times"
 msgstr ""
 
-#: user/views.py:414
+#: user/views.py:423
 msgid "Email address has already been confirmed"
 msgstr ""
 
-#: user/views.py:443 user/views.py:515
+#: user/views.py:452 user/views.py:524
 msgid "Email successfully confirmed"
 msgstr ""
 
-#: user/views.py:467
+#: user/views.py:476
 msgid "No inactive user present for username"
 msgstr ""
 
-#: user/views.py:485
+#: user/views.py:494
 msgid "Email is already confirmed for user"
 msgstr ""
 
-#: user/views.py:497
+#: user/views.py:506
 msgid "Email confirmation pin is incorrect"
 msgstr ""
 
-#: user/views.py:502
+#: user/views.py:511
 msgid "Email confirmation pin has expired"
 msgstr ""
 
-#: user/views.py:506
+#: user/views.py:515
 msgid "No matching active username/email found"
 msgstr ""
 
-#: user/views.py:522 user/views.py:570
+#: user/views.py:531 user/views.py:579
 msgid "Email change mail successfully sent"
 msgstr ""
 
-#: user/views.py:576 user/views.py:646
+#: user/views.py:585 user/views.py:655
 msgid "Email successfully changed"
 msgstr ""
 
-#: user/views.py:611
+#: user/views.py:620
 msgid "Email is already changed for user"
 msgstr ""
 
-#: user/views.py:623
+#: user/views.py:632
 msgid "Email change pin is incorrect"
 msgstr ""
 
-#: user/views.py:628
+#: user/views.py:637
 msgid "Email change pin has expired"
 msgstr ""
 
-#: user/views.py:632
+#: user/views.py:641
 msgid "No matching active change change request found"
 msgstr ""
 
-#: user/views.py:641
+#: user/views.py:650
 msgid "email already used for account creation"
 msgstr ""

--- a/neatplus/serializers.py
+++ b/neatplus/serializers.py
@@ -1,10 +1,48 @@
 from ckeditor_uploader.fields import RichTextUploadingField
 from django.conf import settings
+from django.contrib.auth import get_user_model
 from rest_framework.fields import CharField
 from rest_framework.serializers import ModelSerializer
 
 CKEDITOR_LOCATION = f"/{settings.MEDIA_LOCATION}/{settings.CKEDITOR_UPLOAD_PATH}"
 ORIGINAL_TEXT = f'src="{CKEDITOR_LOCATION}'
+
+UserModel = get_user_model()
+
+
+class UserModelSerializer(ModelSerializer):
+    def build_relational_field(self, field_name, relation_info):
+        if (
+            relation_info.related_model == get_user_model()
+            and relation_info.to_field is None
+        ):
+            relation_info = relation_info._replace(to_field="username")
+        return super().build_relational_field(field_name, relation_info)
+
+
+class ExcludeUserStampedFieldSerializer(ModelSerializer):
+    def __init__(self, *args, **kwargs):
+        if hasattr(self.Meta, "exclude"):
+            excluded_fields = self.Meta.exclude
+            if "created_by" not in excluded_fields:
+                excluded_fields += ("created_by",)
+            if "updated_by" not in excluded_fields:
+                excluded_fields += ("updated_by",)
+            self.Meta.exclude = excluded_fields
+        elif hasattr(self.Meta, "fields"):
+            fields = self.Meta.fields
+            if type(fields, str):
+                delattr(self.Meta, "fields")
+                self.Meta.exclude = ("created_by", "updated_by")
+            else:
+                fields = list(fields)
+                if "created_by" in fields:
+                    fields.remove("created_by")
+                if "updated_by" in fields:
+                    fields.remove("updated_by")
+                self.Meta.fields = tuple(fields)
+
+        super().__init__(*args, **kwargs)
 
 
 class RichTextUploadingSerializerField(CharField):
@@ -19,7 +57,7 @@ class RichTextUploadingSerializerField(CharField):
         return data
 
 
-class RichTextUploadingModelSerializer(ModelSerializer):
+class RichTextUploadingModelSerializer(UserModelSerializer):
     def __init__(self, *args, **kwargs):
         self.serializer_field_mapping[
             RichTextUploadingField

--- a/neatplus/settings.py
+++ b/neatplus/settings.py
@@ -574,4 +574,7 @@ else:
     DRF_RECAPTCHA_TESTING = True
 
 # silenced system checks
-SILENCED_SYSTEM_CHECKS = ["drf_spectacular.W001"]
+SILENCED_SYSTEM_CHECKS = [
+    "drf_spectacular.W001",  # Silence all drf spectacular W001 system check
+    "security.W019",  # Silence X_FRAME_OPTIONS is not set to 'DENY'. Required to be 'SAME_ORIGIN' for django-admin-interface
+]

--- a/notification/serializers.py
+++ b/notification/serializers.py
@@ -1,10 +1,12 @@
 from django.contrib.contenttypes.models import ContentType
 from rest_framework import serializers
 
+from neatplus.serializers import UserModelSerializer
+
 from .models import Notice, Notification
 
 
-class NotificationSerializer(serializers.ModelSerializer):
+class NotificationSerializer(UserModelSerializer):
     actor_content_type = serializers.SlugRelatedField(
         queryset=ContentType.objects.all(),
         slug_field="model",
@@ -48,7 +50,7 @@ class UnReadCountResponseSerializer(serializers.Serializer):
     unread_count = serializers.IntegerField()
 
 
-class NoticeSerializer(serializers.ModelSerializer):
+class NoticeSerializer(UserModelSerializer):
     class Meta:
         model = Notice
         fields = "__all__"

--- a/organization/filters.py
+++ b/organization/filters.py
@@ -6,7 +6,7 @@ from .models import Organization, OrganizationMemberRequest
 class OrganizationFilter(FilterSet):
     class Meta:
         model = Organization
-        fields = {"title": ["exact"], "admins": ["exact"], "members": ["exact"]}
+        fields = {"title": ["exact"]}
 
 
 class OrganizationMemberRequestFilter(FilterSet):

--- a/organization/permissions.py
+++ b/organization/permissions.py
@@ -1,6 +1,11 @@
 from rest_framework import permissions
 
 
+class IsOrganizationAdmin(permissions.IsAuthenticated):
+    def has_object_permission(self, request, view, obj):
+        return request.user in obj.admins.all()
+
+
 class IsMemberRequestOrganizationAdmin(permissions.IsAuthenticated):
     def has_object_permission(self, request, view, obj):
         return request.user in obj.organization.admins.all()

--- a/organization/serializers.py
+++ b/organization/serializers.py
@@ -1,21 +1,31 @@
 from rest_framework import serializers
 
+from neatplus.serializers import ExcludeUserStampedFieldSerializer, UserModelSerializer
+from user.serializers import UserSerializer
+
 from .models import Organization, OrganizationMemberRequest
 
 
-class OrganizationSerializer(serializers.ModelSerializer):
+class OrganizationSerializer(UserModelSerializer, ExcludeUserStampedFieldSerializer):
+    is_admin = serializers.SerializerMethodField()
+    is_member = serializers.SerializerMethodField()
+
     class Meta:
         model = Organization
-        fields = "__all__"
+        exclude = (
+            "admins",
+            "members",
+        )
+
+    def get_is_admin(self, obj):
+        return self.context["request"].user in obj.admins.all()
+
+    def get_is_member(self, obj):
+        return self.context["request"].user in obj.members.all()
 
 
-class CreateOrganizationSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = Organization
-        exclude = ("admins", "members")
-
-
-class OrganizationMemberRequestSerializer(serializers.ModelSerializer):
+class OrganizationMemberRequestSerializer(UserModelSerializer):
+    user = UserSerializer()
     is_organization_admin = serializers.SerializerMethodField()
 
     class Meta:
@@ -24,3 +34,13 @@ class OrganizationMemberRequestSerializer(serializers.ModelSerializer):
 
     def get_is_organization_admin(self, obj):
         return self.context["request"].user in obj.organization.admins.all()
+
+
+class OrganizationUserSerializer(serializers.Serializer):
+    user = serializers.CharField()
+    role = serializers.ChoiceField(choices=["admin", "member"])
+
+
+class ListOrganizationUserSerializer(serializers.Serializer):
+    user = serializers.DictField()
+    role = serializers.ChoiceField(choices=["admin", "member"])

--- a/organization/views.py
+++ b/organization/views.py
@@ -1,3 +1,4 @@
+from django.db import transaction
 from django.db.models import Q
 from django.utils.translation import gettext_lazy as _
 from drf_spectacular.utils import extend_schema, inline_serializer
@@ -8,20 +9,28 @@ from rest_framework.response import Response
 from neatplus.views import UserStampedModelViewSetMixin
 from project.models import Project
 from project.serializers import CreateProjectSerializer
+from user.models import User
+from user.serializers import UserSerializer
 
 from .filters import OrganizationFilter, OrganizationMemberRequestFilter
 from .models import Organization, OrganizationMemberRequest
-from .permissions import IsMemberRequestOrganizationAdmin, IsOrganizationAdminOrReadOnly
+from .permissions import (
+    IsMemberRequestOrganizationAdmin,
+    IsOrganizationAdmin,
+    IsOrganizationAdminOrReadOnly,
+)
 from .serializers import (
-    CreateOrganizationSerializer,
+    ListOrganizationUserSerializer,
     OrganizationMemberRequestSerializer,
     OrganizationSerializer,
+    OrganizationUserSerializer,
 )
 
 
 class OrganizationViewSet(UserStampedModelViewSetMixin, viewsets.ModelViewSet):
     filterset_class = OrganizationFilter
     permission_classes = [IsOrganizationAdminOrReadOnly]
+    serializer_class = OrganizationSerializer
 
     def get_queryset(self):
         authenticated_user = self.request.user
@@ -29,14 +38,10 @@ class OrganizationViewSet(UserStampedModelViewSetMixin, viewsets.ModelViewSet):
             filter_statement = Q(status="accepted") | Q(created_by=self.request.user)
         else:
             filter_statement = Q(status="accepted")
-        return Organization.objects.filter(filter_statement)
-
-    def get_serializer_class(self):
-        if self.name and self.serializer_class:
-            return self.serializer_class
-        if self.action == "create":
-            return CreateOrganizationSerializer
-        return OrganizationSerializer
+        return Organization.objects.filter(filter_statement).prefetch_related(
+            "admins",
+            "members",
+        )
 
     @extend_schema(
         responses=inline_serializer(
@@ -95,6 +100,109 @@ class OrganizationViewSet(UserStampedModelViewSetMixin, viewsets.ModelViewSet):
             {"detail": _("Successfully requested member access")},
             status=status.HTTP_200_OK,
         )
+
+    @action(
+        methods=["get"],
+        detail=True,
+        permission_classes=[IsOrganizationAdmin],
+        serializer_class=ListOrganizationUserSerializer,
+    )
+    def users(self, request, *args, **kwargs):
+        organization = self.get_object()
+        users = []
+        user_serializer_class = UserSerializer
+        for admin in organization.admins.all():
+            admin_data = user_serializer_class(admin).data
+            users.append({"user": admin_data, "role": "admin"})
+        for member in organization.members.all():
+            member_data = user_serializer_class(member).data
+            users.append({"user": member_data, "role": "member"})
+        serializer = self.get_serializer(data=users, many=True)
+        if not serializer.is_valid():
+            return Response(
+                serializer.errors, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
+        return Response(serializer.data)
+
+    @extend_schema(
+        request=OrganizationUserSerializer(many=True),
+        responses=inline_serializer(
+            name="OrganizationAddUserSerializer",
+            fields={
+                "detail": serializers.CharField(
+                    default=_("Successfully added all valid users")
+                )
+            },
+        ),
+    )
+    @action(
+        methods=["post"],
+        detail=True,
+        permission_classes=[IsOrganizationAdmin],
+        serializer_class=OrganizationUserSerializer,
+    )
+    def update_or_add_users(self, request, *args, **kwargs):
+        organization = self.get_object()
+        serializer = self.get_serializer(data=request.data, many=True)
+        if not serializer.is_valid():
+            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+        try:
+            with transaction.atomic():
+                for validated_datum in serializer.validated_data:
+                    user = User.objects.filter(username=validated_datum["user"]).first()
+                    if user:
+                        if validated_datum["role"] == "admin":
+                            organization.admins.add(user)
+                            organization.members.remove(user)
+                        elif validated_datum["role"] == "member":
+                            organization.members.add(user)
+                            organization.admins.remove(user)
+        except Exception:
+            return Response(
+                {"error": _("Failed to add users to organization")},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        return Response({"detail": _("Successfully added all valid users")})
+
+    @extend_schema(
+        request=OrganizationUserSerializer(many=True),
+        responses=inline_serializer(
+            name="OrganizationAddUserSerializer",
+            fields={
+                "detail": serializers.CharField(
+                    default=_("Successfully removed all valid users")
+                )
+            },
+        ),
+    )
+    @action(
+        methods=["post"],
+        detail=True,
+        permission_classes=[IsOrganizationAdmin],
+        serializer_class=OrganizationUserSerializer,
+    )
+    def remove_users(self, request, *args, **kwargs):
+        organization = self.get_object()
+        serializer = self.get_serializer(data=request.data, many=True)
+        if not serializer.is_valid():
+            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+        try:
+            with transaction.atomic():
+                for validated_datum in serializer.validated_data:
+                    user = User.objects.filter(username=validated_datum["user"]).first()
+                    if user:
+                        if validated_datum["role"] == "admin":
+                            organization.admins.remove(user)
+                        elif validated_datum["role"] == "member":
+                            organization.members.remove(user)
+        except Exception:
+            return Response(
+                {"error": _("Failed to remove users from organization")},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        return Response({"detail": _("Successfully removed all valid users")})
 
 
 class OrganizationMemberRequestViewSet(

--- a/project/serializers.py
+++ b/project/serializers.py
@@ -1,13 +1,14 @@
 from django.utils.translation import gettext_lazy as _
 from rest_framework import serializers
 
+from neatplus.serializers import UserModelSerializer
 from organization.serializers import OrganizationSerializer
 from user.serializers import UserSerializer
 
 from .models import Project, ProjectUser
 
 
-class ProjectUserSerializer(serializers.ModelSerializer):
+class ProjectUserSerializer(UserModelSerializer):
     user = UserSerializer()
 
     class Meta:
@@ -15,7 +16,7 @@ class ProjectUserSerializer(serializers.ModelSerializer):
         exclude = ("project",)
 
 
-class ProjectSerializer(serializers.ModelSerializer):
+class ProjectSerializer(UserModelSerializer):
     created_by = UserSerializer()
     organization_title = serializers.SerializerMethodField(read_only=True)
     is_admin_or_owner = serializers.SerializerMethodField(read_only=True)
@@ -40,7 +41,7 @@ class ProjectSerializer(serializers.ModelSerializer):
         return super().update(instance, validated_data)
 
 
-class CreateProjectSerializer(serializers.ModelSerializer):
+class CreateProjectSerializer(UserModelSerializer):
     class Meta:
         model = Project
         exclude = ("users",)
@@ -69,13 +70,13 @@ class CreateProjectSerializer(serializers.ModelSerializer):
         return data
 
 
-class UpsertProjectUserSerializer(serializers.ModelSerializer):
+class UpsertProjectUserSerializer(UserModelSerializer):
     class Meta:
         model = ProjectUser
         exclude = ("project",)
 
 
-class RemoveProjectUserSerializer(serializers.ModelSerializer):
+class RemoveProjectUserSerializer(UserModelSerializer):
     class Meta:
         model = ProjectUser
         fields = ("user",)

--- a/project/tests/test_API.py
+++ b/project/tests/test_API.py
@@ -181,8 +181,8 @@ class APITest(FullTestCase):
             kwargs={"version": "v1", "pk": self.project.pk},
         )
         data = [
-            {"user": first_user.pk, "permission": "write"},
-            {"user": second_user.pk},
+            {"user": first_user.username, "permission": "write"},
+            {"user": second_user.username},
         ]
         post_response = self.client.post(url, data=data, format="json")
         self.assertEqual(
@@ -209,8 +209,8 @@ class APITest(FullTestCase):
             kwargs={"version": "v1", "pk": self.project.pk},
         )
         data = [
-            {"user": first_user.pk},
-            {"user": second_user.pk},
+            {"user": first_user.username},
+            {"user": second_user.username},
         ]
         post_response = self.client.post(url, data=data, format="json")
         self.assertEqual(

--- a/statement/serializers.py
+++ b/statement/serializers.py
@@ -1,5 +1,7 @@
 from rest_framework import serializers
 
+from neatplus.serializers import UserModelSerializer
+
 from .models import (
     Mitigation,
     Opportunity,
@@ -12,49 +14,49 @@ from .models import (
 )
 
 
-class StatementTopicSerializer(serializers.ModelSerializer):
+class StatementTopicSerializer(UserModelSerializer):
     class Meta:
         model = StatementTopic
         fields = "__all__"
 
 
-class StatementTagGroupSerializer(serializers.ModelSerializer):
+class StatementTagGroupSerializer(UserModelSerializer):
     class Meta:
         model = StatementTagGroup
         fields = "__all__"
 
 
-class StatementTagSerializer(serializers.ModelSerializer):
+class StatementTagSerializer(UserModelSerializer):
     class Meta:
         model = StatementTag
         fields = "__all__"
 
 
-class StatementSerializer(serializers.ModelSerializer):
+class StatementSerializer(UserModelSerializer):
     class Meta:
         model = Statement
         fields = "__all__"
 
 
-class MitigationSerializer(serializers.ModelSerializer):
+class MitigationSerializer(UserModelSerializer):
     class Meta:
         model = Mitigation
         fields = "__all__"
 
 
-class OpportunitySerializer(serializers.ModelSerializer):
+class OpportunitySerializer(UserModelSerializer):
     class Meta:
         model = Opportunity
         fields = "__all__"
 
 
-class QuestionStatementSerializer(serializers.ModelSerializer):
+class QuestionStatementSerializer(UserModelSerializer):
     class Meta:
         model = QuestionStatement
         exclude = ("created_by", "updated_by", "created_at", "modified_at")
 
 
-class OptionStatementSerializer(serializers.ModelSerializer):
+class OptionStatementSerializer(UserModelSerializer):
     class Meta:
         model = OptionStatement
         exclude = ("created_by", "updated_by", "created_at", "modified_at")

--- a/summary/serializers.py
+++ b/summary/serializers.py
@@ -1,9 +1,11 @@
 from rest_framework import serializers
 
+from neatplus.serializers import UserModelSerializer
+
 from .models import SurveyResult, SurveyResultFeedback
 
 
-class SurveyResultSerializer(serializers.ModelSerializer):
+class SurveyResultSerializer(UserModelSerializer):
     class Meta:
         model = SurveyResult
         fields = "__all__"

--- a/support/serializers.py
+++ b/support/serializers.py
@@ -1,6 +1,6 @@
 from rest_framework import serializers
 
-from neatplus.serializers import RichTextUploadingModelSerializer
+from neatplus.serializers import RichTextUploadingModelSerializer, UserModelSerializer
 
 from .models import (
     Action,
@@ -11,25 +11,25 @@ from .models import (
 )
 
 
-class LegalDocumentSerializer(serializers.ModelSerializer):
+class LegalDocumentSerializer(UserModelSerializer):
     class Meta:
         model = LegalDocument
         fields = "__all__"
 
 
-class FrequentlyAskedQuestionSerializer(serializers.ModelSerializer):
+class FrequentlyAskedQuestionSerializer(UserModelSerializer):
     class Meta:
         model = FrequentlyAskedQuestion
         fields = "__all__"
 
 
-class ResourceTagSerializer(serializers.ModelSerializer):
+class ResourceTagSerializer(UserModelSerializer):
     class Meta:
         model = ResourceTag
         fields = "__all__"
 
 
-class ResourceSerializer(serializers.ModelSerializer):
+class ResourceSerializer(UserModelSerializer):
     class Meta:
         model = Resource
         fields = "__all__"

--- a/survey/serializers.py
+++ b/survey/serializers.py
@@ -6,7 +6,7 @@ from rest_framework import serializers
 from rest_framework.fields import ImageField
 from rest_framework_gis.fields import GeometryField
 
-from neatplus.serializers import RichTextUploadingModelSerializer
+from neatplus.serializers import RichTextUploadingModelSerializer, UserModelSerializer
 from summary.serializers import SurveyResultSerializer, WritableSurveyResultSerializer
 
 from .models import (
@@ -19,7 +19,7 @@ from .models import (
 )
 
 
-class QuestionGroupSerializer(serializers.ModelSerializer):
+class QuestionGroupSerializer(UserModelSerializer):
     class Meta:
         model = QuestionGroup
         fields = "__all__"
@@ -31,7 +31,7 @@ class QuestionSerializer(RichTextUploadingModelSerializer):
         fields = "__all__"
 
 
-class OptionSerializer(serializers.ModelSerializer):
+class OptionSerializer(UserModelSerializer):
     class Meta:
         model = Option
         fields = "__all__"
@@ -71,7 +71,7 @@ class OptionSerializer(serializers.ModelSerializer):
         return value
 
 
-class SurveySerializer(serializers.ModelSerializer):
+class SurveySerializer(UserModelSerializer):
     class Meta:
         model = Survey
         fields = "__all__"
@@ -81,7 +81,7 @@ class ImageListField(serializers.ListField):
     child = serializers.ImageField()
 
 
-class SurveyAnswerSerializer(serializers.ModelSerializer):
+class SurveyAnswerSerializer(UserModelSerializer):
     formatted_answer = serializers.SerializerMethodField()
 
     answer_type_serializer_mapping = {

--- a/user/serializers.py
+++ b/user/serializers.py
@@ -3,13 +3,19 @@ from django.utils.translation import gettext_lazy as _
 from drf_recaptcha.fields import ReCaptchaV3Field
 from rest_framework import serializers
 
+from neatplus.serializers import UserModelSerializer
+
 from .models import User
 
 
-class UserSerializer(serializers.ModelSerializer):
+class UserSerializer(UserModelSerializer):
     class Meta:
         model = User
-        fields = ("id", "username", "first_name", "last_name", "organization", "role")
+        fields = (
+            "username",
+            "first_name",
+            "last_name",
+        )
 
 
 class PrivateUserSerializer(UserSerializer):
@@ -52,6 +58,10 @@ class ChangePasswordSerializer(serializers.Serializer):
         if not user.check_password(password):
             raise serializers.ValidationError(
                 {"old_password": _("Invalid password for user")}
+            )
+        if attrs["new_password"] != attrs["re_new_password"]:
+            raise serializers.ValidationError(
+                {"error": _("New password and re new password doesn't match")}
             )
         return super().validate(attrs)
 


### PR DESCRIPTION
# BREAKING CHANGE PR
### This PR has breaking change for almost all API of project.
- This PR has breaking changes related to user and organization API.
- Now user API doesn't return ID, organization and role. User field doesn't need ID for adding a user in a related field, instead username is required and username is returned by API.
- User list view API doesn't list any user until using `?search=<search-term>` as query parameter where length of search-term is greater than 2. It searches all active users using username or first name or last name and list all users for which search terms match.
- Organization API doesn't have members and admins list. Instead, action named as users, add_users, remove_users needs to be used to add either admins or members to the organization.

#### Fixes User and organization related security issue